### PR TITLE
Updates for ROS Noetic

### DIFF
--- a/delphi_esr_driver/src/delphi_esr_application.cpp
+++ b/delphi_esr_driver/src/delphi_esr_application.cpp
@@ -161,13 +161,6 @@ void DelphiESRApplication::publish_updates() {
 
         obj.velocity.twist.linear.z = 0;
 
-
-        obj.presence_vector |= cav_msgs::ExternalObject::RANGE_RATE_PRESENCE_VECTOR;
-        obj.range_rate = it.range_rate;
-
-        obj.presence_vector |= cav_msgs::ExternalObject::AZIMUTH_RATE_PRESENCE_VECTOR;
-        obj.azimuth_rate = -it.lat_rate/it.range;
-
         obj.presence_vector |= cav_msgs::ExternalObject::CONFIDENCE_PRESENCE_VECTOR;
         obj.confidence = it.track_status == delphi::TrackStatus::NewTarget ? 0.5 : 1.0;
 

--- a/delphi_esr_driver/src/delphi_esr_application.h
+++ b/delphi_esr_driver/src/delphi_esr_application.h
@@ -2,7 +2,7 @@
 
 #include "delphi_esr_can_client.h"
 #include <cav_driver_utils/can/socketcan_interface/socketcan_interface.h>
-#include <driver_application/driver_application.h>
+#include <cav_driver_utils/driver_application/driver_application.h>
 
 #include <geometry_msgs/TwistStamped.h>
 #include <diagnostic_updater/diagnostic_updater.h>


### PR DESCRIPTION
RANGE_RATE_PRESENCE_VECTOR and AZIMUTH_RATE_PRESENCE_VECTOR are no longer supported. Also, the location of driver_application.h has changed. 