### PR TITLE
Update to package format 3 and run xmllint

### DIFF
--- a/delphi_esr_driver/CMakeLists.txt
+++ b/delphi_esr_driver/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(delphi_esr_driver)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/delphi_esr_driver/package.xml
+++ b/delphi_esr_driver/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>delphi_esr_driver</name>
   <version>1.0.1</version>
   <description>The can driver package</description>
@@ -11,7 +11,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>can_msgs</build_depend>
   <build_depend>cav_driver_utils</build_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>can_msgs</run_depend>
-  <run_depend>cav_driver_utils</run_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>can_msgs</exec_depend>
+  <exec_depend>cav_driver_utils</exec_depend>
 </package>


### PR DESCRIPTION
Update remaining packages that had package format version 2 to version 3 and address any xmllint issues when testing against the package format v3 schema (typically just reordering items).